### PR TITLE
changed all ontology IRIs to SOMA.owl, and removed module imports

### DIFF
--- a/owl/SOMA-ACT.owl
+++ b/owl/SOMA-ACT.owl
@@ -7,10 +7,7 @@
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-ACT.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-PROC.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-STATE.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     

--- a/owl/SOMA-Allen.owl
+++ b/owl/SOMA-Allen.owl
@@ -7,8 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-Allen.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-ELAN.owl
+++ b/owl/SOMA-ELAN.owl
@@ -7,8 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-ELAN.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-ACT.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-IO.owl
+++ b/owl/SOMA-IO.owl
@@ -7,9 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-IO.owl">
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-OBJ.owl
+++ b/owl/SOMA-OBJ.owl
@@ -7,8 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-OBJ.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-PROC.owl
+++ b/owl/SOMA-PROC.owl
@@ -7,9 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-PROC.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-OBJ.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-SAY.owl
+++ b/owl/SOMA-SAY.owl
@@ -7,8 +7,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-SAY.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-ACT.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-STATE.owl
+++ b/owl/SOMA-STATE.owl
@@ -8,9 +8,8 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-STATE.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-OBJ.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 

--- a/owl/SOMA-WF.owl
+++ b/owl/SOMA-WF.owl
@@ -7,10 +7,7 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:SOMA="http://www.ease-crc.org/ont/SOMA.owl#">
-    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA-WF.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-STATE.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/SOMA-ACT.owl"/>
+    <owl:Ontology rdf:about="http://www.ease-crc.org/ont/SOMA.owl">
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
     </owl:Ontology>


### PR DESCRIPTION
This would change all ontology IRIs in to http://www.ease-crc.org/ont/SOMA.owl
The consequence is that Protege will use this as xml:base for new entities.
**BUT** Protege refuses to load two SOMA modules next to each other, stating that SOMA was already loaded and thus ignored.