### PR TITLE
Added a data property to link DOIs to an InformationObject.

### DIFF
--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -880,6 +880,17 @@ Sub-properties are used to distinct between different cases of event endpoint re
     
 
 
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier -->
+
+    <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier">
+        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
+        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:comment>A property linking an InformationObject to a persistent identifier such as a DOI, which can then be used to obtain an address at which a realization (digital file) of the information object can be retrieved.</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://www.ease-crc.org/ont/SOMA.owl#isReificationOf -->
 
     <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#isReificationOf">
@@ -1246,6 +1257,28 @@ Such an event does NOT fall under the definition of Accident here. An example of
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>The EASE view: an Action is an Event in which an Agent executes some Task, typically defined by a Workflow, towards the achievement of some Goal.</rdfs:comment>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject -->
+
+    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>In SOMA-compliant systems, the way to use InformationObjects to specify extra data about an individual entity is to employ the &apos;is about&apos; and &apos;expresses&apos; properties (or their inverses &apos;is reference of&apos; and &apos;is expressed by&apos;) and to supply a persistent identifier for a realization of the InformationObject.
+
+As a prototypical example, consider an individual called Action_XYZ, about which we have some data for which the meaning is described by Description_ABC. The data would be an individual InformationObject_DEF, and the following property assertions would hold:
+
+InformationObject_DEF &apos;is about&apos; Action_XYZ
+InformationObject_DEF expresses Description_ABC
+
+
+Usually, an individual InformationObject would be connected to (at least) an InformationRealization individual. Instead, we provide the data property hasRealizationWithIdentifier, which provides a persistent identifier with which to locate a realization for the information object. Typically, this persistent identifier would be a DOI, from which a URL to a file containing a realization of the information object can be retrieved.</rdfs:comment>
     </rdf:Description>
     
 


### PR DESCRIPTION
It turns out, very little needs to change to support linking info objects to entities.

DUL provides an 'is about' property, with inverse 'is reference of'. The 'is about' property has an InformationObject as domain, and ranges over any entity. This can connect the information object to any individual we have more data about.

DUL also provides an 'expresses' property, with inverse 'is expressed by'. The 'expresses' property has InformationObject as domain, and ranges over social objects such as Concepts or Descriptions. This property therefore can be used to link an InformationObject to what it "means".

I added a comment about InformationObjects to describe this intended pattern of usage, such that it is visible when viewing InformationObject in Protege. This pattern of usage is encoded in the domain/range axioms of the 'expresses' and 'is about' properties.

I also added a new data property to connect the InformationObject to a DOI. Note that in DUL one would more directly connect an InformationRealization to a DOI and an InformationObject, but in the interest of saving a triple it is nice, I think, to have a way of connecting realization DOIs to the InformationObject to which those realizations belong.