### PR TITLE
Added some subclasses of InfoObject

### DIFF
--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -809,6 +809,7 @@ Sub-properties are used to distinct between different cases of event endpoint re
         <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
         <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>A property linking an InformationRealization to a string specifying a format name, e.g. URDF or STL.</rdfs:comment>
     </owl:DatatypeProperty>
     
 

--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -880,6 +880,17 @@ Sub-properties are used to distinct between different cases of event endpoint re
     
 
 
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier -->
+
+    <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier">
+        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
+        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:comment>A property linking an InformationObject to a persistent identifier such as a DOI, which can then be used to obtain an address at which a realization (digital file) of the information object can be retrieved.</rdfs:comment>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://www.ease-crc.org/ont/SOMA.owl#isReificationOf -->
 
     <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#isReificationOf">
@@ -1246,6 +1257,28 @@ Such an event does NOT fall under the definition of Accident here. An example of
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>The EASE view: an Action is an Event in which an Agent executes some Task, typically defined by a Workflow, towards the achievement of some Goal.</rdfs:comment>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject -->
+
+    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>In SOMA-compliant systems, the way to use InformationObjects to specify extra data about an individual entity is to employ the &apos;is about&apos; and &apos;expresses&apos; properties (or their inverses &apos;is reference of&apos; and &apos;is expressed by&apos;) and to supply a persistent identifier for a realization of the InformationObject.
+
+As a prototypical example, consider an individual called Action_XYZ, about which we have some data for which the meaning is described by Description_ABC. The data would be an individual InformationObject_DEF, and the following property assertions would hold:
+
+InformationObject_DEF &apos;is about&apos; Action_XYZ
+InformationObject_DEF expresses Description_ABC
+
+
+Usually, an individual InformationObject would be connected to (at least) an InformationRealization individual. Instead, we provide the data property hasRealizationWithIdentifier, which provides a persistent identifier with which to locate a realization for the information object. Typically, this persistent identifier would be a DOI, from which a URL to a file containing a realization of the information object can be retrieved.</rdfs:comment>
     </rdf:Description>
     
 

--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -1306,7 +1306,7 @@ Such an event does NOT fall under the definition of Accident here. An example of
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier"/>
-                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>In SOMA-compliant systems, the way to use InformationObjects to specify extra data about an individual entity is to employ the &apos;is about&apos; and &apos;expresses&apos; properties (or their inverses &apos;is reference of&apos; and &apos;is expressed by&apos;) and to supply a persistent identifier for a realization of the InformationObject.

--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -885,7 +885,7 @@ Sub-properties are used to distinct between different cases of event endpoint re
     <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier">
         <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
         <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
-        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment>A property linking an InformationObject to a persistent identifier such as a DOI, which can then be used to obtain an address at which a realization (digital file) of the information object can be retrieved.</rdfs:comment>
     </owl:DatatypeProperty>
     

--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -1092,6 +1092,21 @@ Such an event does NOT fall under the definition of Accident here. An example of
     
 
 
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#KinoDynamicData -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#KinoDynamicData">
+        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isAbout"/>
+                <owl:allValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>An InformationObject containing data about how a physical object is put together such that its parts may move relative to each other, and what the physical characteristics of those parts are.</rdfs:comment>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/SOMA.owl#Masterful -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Masterful">
@@ -1114,6 +1129,21 @@ Such an event does NOT fall under the definition of Accident here. An example of
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#TechnicalDiagnosis"/>
         <rdfs:comment>A functional diagnosis of an organism.</rdfs:comment>
         <rdfs:label>Medical diagnosis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#MeshShapeData -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#MeshShapeData">
+        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isAbout"/>
+                <owl:allValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>An InformationObject containing data about the geometry of a physical object.</rdfs:comment>
     </owl:Class>
     
 
@@ -1243,6 +1273,15 @@ Such an event does NOT fall under the definition of Accident here. An example of
     <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Unsuccessfulness">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#SuccessDiagnosis"/>
         <rdfs:comment>A description of a situation with a goal that was not or not fully achieved by some system.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#VideoData -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#VideoData">
+        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:comment>An information object containing data for audio-visual modalities.</rdfs:comment>
     </owl:Class>
     
 

--- a/owl/SOMA.owl
+++ b/owl/SOMA.owl
@@ -803,6 +803,16 @@ Sub-properties are used to distinct between different cases of event endpoint re
     
 
 
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#hasDataFormat -->
+
+    <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasDataFormat">
+        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
+        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://www.ease-crc.org/ont/SOMA.owl#hasEventBegin -->
 
     <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasEventBegin">
@@ -880,13 +890,13 @@ Sub-properties are used to distinct between different cases of event endpoint re
     
 
 
-    <!-- http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier -->
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#hasPersistentIdentifier -->
 
-    <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier">
+    <owl:DatatypeProperty rdf:about="http://www.ease-crc.org/ont/SOMA.owl#hasPersistentIdentifier">
         <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue"/>
-        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-        <rdfs:comment>A property linking an InformationObject to a persistent identifier such as a DOI, which can then be used to obtain an address at which a realization (digital file) of the information object can be retrieved.</rdfs:comment>
+        <rdfs:comment>A property linking an InformationRealization to a persistent identifier such as a DOI, which can then be used to obtain an address at which the realization (i.e. digital file) can be retrieved.</rdfs:comment>
     </owl:DatatypeProperty>
     
 
@@ -1303,10 +1313,36 @@ Such an event does NOT fall under the definition of Accident here. An example of
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject -->
 
     <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject">
+        <rdfs:comment>In SOMA-compliant systems, the way to use InformationObjects to specify extra data about an individual entity is to employ the &apos;is about&apos; and &apos;expresses&apos; properties (or their inverses &apos;is reference of&apos; and &apos;is expressed by&apos;) and to supply a persistent identifier for a realization of the InformationObject.
+
+As a prototypical example, consider an individual called Action_XYZ, about which we have some data for which the meaning is described by Description_ABC. The data would be an individual InformationObject_DEF, and the following property assertions would hold:
+
+InformationObject_DEF &apos;is about&apos; Action_XYZ
+InformationObject_DEF expresses Description_ABC
+
+
+Usually, an individual InformationObject would be connected to (at least) an InformationRealization individual. For example, suppose there is such an InformationRealization individual, InformationRealization_123. Then, this individual will have data properties describing its format and persistent identifier
+
+InformationRealization_123 hasPersistentIdentifier &apos;doi&apos;
+InformationRealization_123 hasDataFormat &apos;urdf&apos;</rdfs:comment>
+    </rdf:Description>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization -->
+
+    <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationRealization">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasRealizationWithIdentifier"/>
+                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasPersistentIdentifier"/>
                 <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#hasDataFormat"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>In SOMA-compliant systems, the way to use InformationObjects to specify extra data about an individual entity is to employ the &apos;is about&apos; and &apos;expresses&apos; properties (or their inverses &apos;is reference of&apos; and &apos;is expressed by&apos;) and to supply a persistent identifier for a realization of the InformationObject.
@@ -1317,7 +1353,10 @@ InformationObject_DEF &apos;is about&apos; Action_XYZ
 InformationObject_DEF expresses Description_ABC
 
 
-Usually, an individual InformationObject would be connected to (at least) an InformationRealization individual. Instead, we provide the data property hasRealizationWithIdentifier, which provides a persistent identifier with which to locate a realization for the information object. Typically, this persistent identifier would be a DOI, from which a URL to a file containing a realization of the information object can be retrieved.</rdfs:comment>
+Usually, an individual InformationObject would be connected to (at least) an InformationRealization individual. For example, suppose there is such an InformationRealization individual, InformationRealization_123. Then, this individual will have data properties describing its format and persistent identifier
+
+InformationRealization_123 hasPersistentIdentifier &apos;doi&apos;
+InformationRealization_123 hasDataFormat &apos;urdf&apos;</rdfs:comment>
     </rdf:Description>
     
 


### PR DESCRIPTION
Added three classes: VideoData, MeshShapeData, and KinoDynamicData. The latter two are restricted to only be about physical objects. I was not sure whether to restrict VideoData to events. One could say that a video is about an object too, I guess, though I would not be opposed to have VideoData for events only.

The classes are not declared disjoint, but if you want they could be.