### PR TITLE
Switch to gokhlayeh/latex:v4

### DIFF
--- a/.github/actions/pythonlatex/Dockerfile
+++ b/.github/actions/pythonlatex/Dockerfile
@@ -1,7 +1,7 @@
-FROM gokhlayeh/latex:latest
+FROM gokhlayeh/latex:v4
 
-RUN apk add --no-cache \
-    py3-pip \
+RUN dnf install  -y --setopt=install_weak_deps=False \
+    python3-pip \
     && \
     python3 -m pip install --no-cache-dir \
     owlready2


### PR DESCRIPTION
First, thanks for using my little project ([`ChiefGokhlayeh/latex`](https://github.com/ChiefGokhlayeh/latex)) in your CI/CD. I'm quite surprised anyone but myself was actually ever going to use it.

Anyway, I tinkered a bit over the last few days, and switched the `gokhlayeh/latex` image over to Fedora. Fedora uses `dnf` (instead of `apk`) as package manager. Unfortunately this has/will break your [Documentation](https://github.com/ease-crc/soma/actions?query=workflow%3ADocumentation) GitHub Workflow. Note that using `latest` in any CI/CD script is always dangerous.

Here I fixed the image to a specific version, which appears to run smooth, at least in [my fork](https://github.com/ChiefGokhlayeh/soma/actions?query=workflow%3ADocumentation).