### PR TITLE
Fix deployment workflow for dul

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -60,6 +60,9 @@ jobs:
           name: DUL Ontology
           path: ./owl/DUL.owl
 
+      - name: Copy DUL
+        run: sudo cp ./owl/DUL.owl $GITHUB_WORKSPACE/build/DUL.owl
+
       - name: Metrics
         run: sudo ./scripts/OntoMetrics.sh $GITHUB_WORKSPACE/build/SOMA.owl $GITHUB_WORKSPACE/build
 


### PR DESCRIPTION
The uploaded ontologies have to be in the build directory.