### PR TITLE
Fix for hermit workflow

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -89,16 +89,13 @@ jobs:
           name: SOMA OWL
           path: ./build
 
-      - name: Download DUL v32
-        run: wget http://www.ontologydesignpatterns.org/ont/dul/DUL_v32.owl -O ./build/DUL_v32.owl
-
-      - name: Download IOLite
-        run: wget http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl -O ./build/IOLite.owl
+      - name: Download DUL
+        run: wget http://www.ease-crc.org/ont/DUL.owl -O ./build/DUL.owl
 
       - name: HermiT
         uses: ./.github/actions/hermit
         with:
-          args: ./build/DUL_v32.owl ./build/IOLite.owl ./build/SOMA-HOME.owl
+          args: ./build/DUL.owl ./build/SOMA-HOME.owl
 
       - name: Print HermiT output
         run: cat ./hermit.output


### PR DESCRIPTION
Always when DUL is down the hermit step will not finish. We uploaded DUL ourself so, if we change the path hermit should work again. Additionally I removed IOLite.

I also removed the version of DUL, because I assume that the DUL version in our repository (and therefore on our server), is the current one we use.