### PR TITLE
Fixed Ontometrics call by moving to a POST call

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -67,15 +67,6 @@ jobs:
 
       - name: Copy all OWL files to be deployed
         run: sudo cp -n ./owl/*.owl $GITHUB_WORKSPACE/build/owl/current
-
-#      - name: Metrics
-#        run: sudo ./scripts/OntoMetrics.sh $GITHUB_WORKSPACE/build/owl/current/SOMA.owl $GITHUB_WORKSPACE/build/files
-
-#      - name: Upload Metrics
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: Metrics
-#          path: ./build/files/metrics.json
       
       - name: Compile NEEM Handbook
         uses: docker://blang/latex:ubuntu
@@ -84,15 +75,6 @@ jobs:
       
       - name: Copy NEEM Handbook
         run: sudo cp $GITHUB_WORKSPACE/docs/NEEM-handbook/main.pdf $GITHUB_WORKSPACE/build/files/NEEM-Handbook.pdf
-      
-      - name: Deploy files current
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.ref == 'refs/heads/master'
-        with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/files
-          TARGET_FOLDER: /files/current
 
       - name: Deploy owl current
         uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -113,6 +95,26 @@ jobs:
           TARGET_FOLDER: owl/${{ github.event.release.tag_name }}
           #TARGET_FOLDER: owl/${{ GITHUB_REF/refs\/tags\// }}
           #TARGET_FOLDER: owl/${{ GITHUB_REF#refs/tags/ }}
+
+      # Metrics have to be created after the deployment step, because 
+      # OntoMetrics only allows POST with an URI at the moment
+      - name: Metrics
+        run: sudo ./scripts/OntoMetrics.sh $GITHUB_WORKSPACE/build/owl/current/SOMA.owl $GITHUB_WORKSPACE/build/files
+
+      - name: Upload Metrics
+        uses: actions/upload-artifact@v1
+        with:
+          name: Metrics
+          path: ./build/files/metrics.json
+
+      - name: Deploy files current
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.ref == 'refs/heads/master'
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build/files
+          TARGET_FOLDER: /files/current
 
       - name: Deploy files tag
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -75,6 +75,15 @@ jobs:
       
       - name: Copy NEEM Handbook
         run: sudo cp $GITHUB_WORKSPACE/docs/NEEM-handbook/main.pdf $GITHUB_WORKSPACE/build/files/NEEM-Handbook.pdf
+      
+      - name: Deploy files current
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.ref == 'refs/heads/master'
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build/files
+          TARGET_FOLDER: /files/current
 
       - name: Deploy owl current
         uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -99,7 +108,18 @@ jobs:
       # Metrics have to be created after the deployment step, because 
       # OntoMetrics only allows POST with an URI at the moment
       - name: Metrics
-        run: sudo ./scripts/OntoMetrics.sh $GITHUB_WORKSPACE/build/owl/current/SOMA.owl $GITHUB_WORKSPACE/build/files
+        if: github.ref == 'refs/heads/master'
+        run: |
+          sudo ./scripts/OntoMetrics.sh \
+          https://raw.githubusercontent.com/ease-crc/soma/gh-pages/owl/current/SOMA.owl \
+          $GITHUB_WORKSPACE/build/files
+
+      - name: Metrics
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo ./scripts/OntoMetrics.sh \
+          https://raw.githubusercontent.com/ease-crc/soma/gh-pages/owl/${{ github.event.release.tag_name }}/SOMA.owl \
+          $GITHUB_WORKSPACE/build/files
 
       - name: Upload Metrics
         uses: actions/upload-artifact@v1

--- a/scripts/OntoMetrics.sh
+++ b/scripts/OntoMetrics.sh
@@ -7,22 +7,13 @@ BASEDIR=$(dirname "$0")
 # The local OWL file
 OWL_FILE="$1"
 # The server URL
-HOST="http://opi.informatik.uni-rostock.de/api"
+HOST="http://opi.informatik.uni-rostock.de/api?url"
 
 echo "${BASEDIR}"
 
 # the web-service return HTML with a link to XML data
-echo "fetching result from https://ontometrics.informatik.uni-rostock.de"
-echo "@${OWL_FILE}"
-curl ${HOST} \
-	-H 'Server: Apache/2.4.38 (Debian)' \
-	-H 'saved: true' \
-	-H 'Content-Type: application/xml' \
-	-H 'Vary: Accept-Encoding' \
-	-H 'Content-Encoding: gzip' \
-	-H 'Keep-Alive: timeout=5, max=100' \
-	-H 'Connection: keep-alive' \
-	--data "@${OWL_FILE}"  > $2/metrics.xml
+echo "fetching result from ${HOST}=${OWL_FILE}"
+curl -X ${HOST}=${OWL_FILE}  > $2/metrics.xml
 
 # convert to JSON
 echo "writing metrics.json"

--- a/scripts/OntoMetrics.sh
+++ b/scripts/OntoMetrics.sh
@@ -13,7 +13,7 @@ echo "${BASEDIR}"
 
 # the web-service return HTML with a link to XML data
 echo "fetching result from ${HOST}=${OWL_FILE}"
-curl -X ${HOST}=${OWL_FILE}  > $2/metrics.xml
+curl ${HOST}=${OWL_FILE}  > $2/metrics.xml
 
 # convert to JSON
 echo "writing metrics.json"


### PR DESCRIPTION
Ontometrics GET interface is not working anymore, therefore I switched to POST. It was necessary to move the metrics step after the "deploying the ontologies" step to have the current OWL file accessible over the URI.

Here is my successful CI run with the new metrics file:

https://github.com/sasjonge/soma/actions/runs/2740607407

Because of the move to POST, I had to add an extra step for a release, so that the metrics are generated from the released version and not the one published as "current". 