### PR TITLE
Minor fix for xml to json converter

### DIFF
--- a/scripts/xml2json.py
+++ b/scripts/xml2json.py
@@ -173,7 +173,7 @@ def xml2json(xmlstring, options, strip_ns=1, strip=1):
 
     """Convert an XML string into a JSON string."""
 
-    elem = ET.fromstring(xmlstring)
+    elem = ET.fromstring(xmlstring.replace('\n',''))
     return elem2json(elem, options, strip_ns=strip_ns, strip=strip)
 
 


### PR DESCRIPTION
The new ontometric script creates an xml that contains new lines after each field. Somehow the xml2json script does not work correctly with it. See the broken output here:

https://github.com/ease-crc/soma/blob/1f6fe19f549152d957fdaac6e044a90434750dbe/files/current/metrics.json

`{"Basemetrics": {"Axioms": {"#tail": "\n", "#text": "3797"},
`
should have the form

`{"Basemetrics": {"Axioms": "3797", `

This PR is a simple fix, that will remove the new lines. With this changes we should see the metrics on the website again.