### PR TITLE
Renamed last iolite URI's

### DIFF
--- a/owl/SOMA-ACT.owl
+++ b/owl/SOMA-ACT.owl
@@ -329,7 +329,7 @@ For Manipulating, it is the movement of the hand(s) and the change in functional
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment xml:lang="en">An action in which an Agent uses some actuator for communication purposes.</rdfs:comment>
@@ -1302,10 +1302,11 @@ As such, an explicit assertion is needed to make a Situation a nonmanifested one
     
 
 
-    <!-- http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject -->
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject -->
 
-    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject">
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject">
         <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
         <rdfs:label xml:lang="en">Linguistic object</rdfs:label>
     </owl:Class>
     

--- a/owl/SOMA-SAY.owl
+++ b/owl/SOMA-SAY.owl
@@ -232,7 +232,7 @@ Let xA, xP be objects filling the agent, patient roles of this schema. Then one 
     <!-- http://www.ease-crc.org/ont/SOMA.owl#ClausalObject -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#ClausalObject">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#Phrase"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#Phrase"/>
         <rdfs:comment>A clause is a phrase containing a subject and a predicate.</rdfs:comment>
         <rdfs:label>Clausal object</rdfs:label>
     </owl:Class>
@@ -765,18 +765,20 @@ Let xL, xR be objects filling the locatum, relatum roles of this schema. Then on
     
 
 
-    <!-- http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject -->
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject -->
 
-    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject"/>
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#InformationObject"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
     </owl:Class>
     
 
 
-    <!-- http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#Phrase -->
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#Phrase -->
 
-    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#Phrase">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl#LinguisticObject"/>
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Phrase">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
     </owl:Class>
 </rdf:RDF>
 


### PR DESCRIPTION
This PR would resolve https://github.com/ease-crc/soma/issues/213

The last iolite reference creates problems with namespaces in KnowRob (we don't import iolite anymore, so the iolite prefix is not defined, see https://github.com/knowrob/knowrob/blob/808ee2b4a7e4307a1dac17b621845fefefb91fc5/src/model/SOMA.pl#L330), so I would rename the concepts by using the SOMA URI prefix.