### PR TITLE
Quickfix wrong InformationObject

### DIFF
--- a/owl/SOMA-SAY.owl
+++ b/owl/SOMA-SAY.owl
@@ -526,6 +526,14 @@ Note that in a semantic sense such clauses always request information, but in a 
     
 
 
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject">
+        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/SOMA.owl#LocutionaryAction -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#LocutionaryAction">
@@ -573,6 +581,15 @@ We additionally require a Locutionary Act to be performed by an Agent, not an Ac
     <!-- http://www.ease-crc.org/ont/SOMA.owl#Patient -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Patient"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/SOMA.owl#Phrase -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Phrase">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject"/>
+        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
+    </owl:Class>
     
 
 
@@ -764,24 +781,6 @@ This is also known as FunctionalControlExternal in GUM (Bateman et al. 2010).
 
 Let xL, xR be objects filling the locatum, relatum roles of this schema. Then one can infer that xL isSupportedBy xR.</rdfs:comment>
         <rdfs:label xml:lang="en">Support theory</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#InformationObject"/>
-        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/SOMA.owl#Phrase -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/SOMA.owl#Phrase">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/SOMA.owl#LinguisticObject"/>
-        <rdfs:isDefinedBy rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
     </owl:Class>
 </rdf:RDF>
 


### PR DESCRIPTION
There was an error in SOMA SAY, probably from #273, where `http://www.ease-crc.org/ont/SOMA.owl#InformationObject` was wrongfully introduced instead of using `http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#InformationObject`.