### PR TITLE
Removed SOMA from SOMA-HOME

### DIFF
--- a/scripts/java/application.yaml
+++ b/scripts/java/application.yaml
@@ -8,4 +8,4 @@ ontology:
       new-iri: http://www.ease-crc.org/ont/SOMA.owl # Optional, if the IRI of the collapsed version should be different from the original
     - ontology: SOMA-HOME
       out-path: ../../build/owl/current/SOMA-HOME.owl
-      except: DUL
+      except: DUL, SOMA


### PR DESCRIPTION
At the moment we would have duplicate triples in KnowRob if they appear in SOMA and SOMA-HOME. It also seems to make more sense to me to have SOMA-HOME import SOMA instead of the current merging. 

I wanted to create a SOMA-HOME-bundled file but just adding it to the application.yaml would throw an error.