### PR TITLE
USD.owl now uses http://www.ease-crc.org/ont/DUL.owl

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Compile
         run: |
-          mvn spring-boot:run -f scripts/java/pom.xml \
+          mvn --no-transfer-progress spring-boot:run -f scripts/java/pom.xml \
              -Dspring-boot.run.arguments="--versionInfo=current"
 
       - name: Upload OWL file

--- a/owl/USD.owl
+++ b/owl/USD.owl
@@ -10,7 +10,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:xformOp="https://ease-crc.org/ont/USD#xformOp:">
     <owl:Ontology rdf:about="https://ease-crc.org/ont/USD.owl">
-        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
+        <owl:imports rdf:resource="http://www.ease-crc.org/ont/DUL.owl"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The purpose of the USD ontology is to establish a graph model of the USD language, and to support translation from USD to a KG representation of scene graphs. To this end, the core vocabulary of USD is defined in terms of an upper-level ontology. In addition, a set of re-usable built-in schemata that are used in the USD language to describe prims are defined. In order to fasciliate translation, the ontological model attempts to replicate the structure of USD as closely as possible while in addition entailing semantics of USD entities.</rdfs:comment>
         <rdfs:label>USD Ontology</rdfs:label>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0.1</owl:versionInfo>

--- a/scripts/java/src/main/java/main/GuardingXmlCatalogIriMapper.java
+++ b/scripts/java/src/main/java/main/GuardingXmlCatalogIriMapper.java
@@ -1,0 +1,38 @@
+package main;
+
+import org.protege.xmlcatalog.CatalogUtilities;
+import org.protege.xmlcatalog.XMLCatalog;
+import org.protege.xmlcatalog.entry.Entry;
+import org.protege.xmlcatalog.redirect.UriRedirectVisitor;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntologyIRIMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Iterator;
+
+public class GuardingXmlCatalogIriMapper implements OWLOntologyIRIMapper {
+    private XMLCatalog catalog;
+
+    public GuardingXmlCatalogIriMapper(File f) throws MalformedURLException, IOException {
+        this(CatalogUtilities.parseDocument(f.toURI().toURL()));
+    }
+
+    public GuardingXmlCatalogIriMapper(XMLCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    public IRI getDocumentIRI(IRI original) {
+        UriRedirectVisitor visitor = new UriRedirectVisitor(original.toURI());
+
+        for (Entry subEntry : catalog.getEntries()) {
+            subEntry.accept(visitor);
+            if (visitor.getRedirect() != null) {
+                return IRI.create(visitor.getRedirect());
+            }
+        }
+        throw new RuntimeException("You are trying to load an ontology from an online source, but we decided to self-host them, e.g, DUL. The ontology you are trying to load is: " + original);
+    }
+}

--- a/scripts/java/src/main/java/main/OntologyManager.java
+++ b/scripts/java/src/main/java/main/OntologyManager.java
@@ -44,8 +44,12 @@ public class OntologyManager {
 
 	@SuppressWarnings("OverlyBroadThrowsClause")
 	private void loadCatalog(final Path ontologyDirectory) throws IOException {
-		final OWLOntologyIRIMapper xmlCatalogIriMapper = new XMLCatalogIRIMapper(
+		// use this if you want to prohibit ontologies being loaded from online
+		final OWLOntologyIRIMapper xmlCatalogIriMapper = new GuardingXmlCatalogIriMapper(
 				ontologyDirectory.resolve(XML_CATALOG_PATH).toFile());
+		// use this if you want to allow to load ontologies from online
+		// final OWLOntologyIRIMapper xmlCatalogIriMapper = new XMLCatalogIRIMapper(
+		// 		ontologyDirectory.resolve(XML_CATALOG_PATH).toFile());
 		ontologyManager.getIRIMappers().add(xmlCatalogIriMapper);
 	}
 

--- a/scripts/java/src/main/java/main/ci_runners/OntologySaver.java
+++ b/scripts/java/src/main/java/main/ci_runners/OntologySaver.java
@@ -35,6 +35,7 @@ public class OntologySaver implements CIRunnable {
 			if (ontologyConfig.format() == null) {
 				ontology.saveOntology();
 			} else {
+				LOGGER.info("Using format {}", ontologyConfig.format());
 				ontology.saveOntology(ontologyConfig.format());
 			}
 		}


### PR DESCRIPTION
USD.owl used the original DUL.owl from ontologydesignpatterns.org, which the CI does not like (this is intentional, since we decided to self-host DUL). This fixes this issue, and also makes it so that the CI will give a better exception when this happens again.